### PR TITLE
Add move tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 all:
 	mkdir -p json/compact
 	go run tools/gensplices/gen.go > json/compact/splices.json
+	go run tools/genmoves/gen.go > json/compact/moves.json
 

--- a/tools/genmoves/gen.go
+++ b/tools/genmoves/gen.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2017 Ramesh Vyaghrapuri. All rights reserved.
+// Use of this source code is governed by a MIT-style license
+// that can be found in the LICENSE file.
+
+// main generates json/compact/moves.json.  Please see
+// github.com/dotchain/dataset
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/dotchain/dataset/tools/lib"
+	"github.com/dotchain/dot"
+	"log"
+	"strings"
+)
+
+var preamble = `
+{
+	"format": "compact",
+	"test": [
+`
+var postamble = `
+	]
+}
+`
+
+func main() {
+	fmt.Println(preamble)
+	defer fmt.Println(postamble)
+
+	input := "abcdefgh"
+	// Note that the alphabet is deliberately unicode to make sure
+	// that the tests work properly with this.
+	alphabet := strings.Split("𝐀𝐁𝐂𝐃𝐄𝐅𝐆𝐇𝐈𝐉𝐊𝐋𝐌𝐍𝐎𝐏", "")
+
+	t := dot.Transformer{}
+	x := &lib.Moves{Input: input}
+	first := ""
+	compact := lib.Compact{}
+	x.ForEachUniquePair(alphabet, func(input, left, right string) {
+		inputl, l := compact.Decode(left)
+		inputr, r := compact.Decode(right)
+		if inputl != inputr || input != inputl {
+			log.Fatal("Invalid inputs", inputl, inputr, left, right)
+		}
+		lx, rx := []dot.Change{l}, []dot.Change{r}
+		mergedl, mergedr := t.MergeChanges(lx, rx)
+		allLeft := append([]dot.Change{l}, mergedl...)
+		allRight := append([]dot.Change{r}, mergedr...)
+
+		encodedl := compact.Encode(input, allLeft)
+		encodedr := compact.Encode(input, allRight)
+
+		outputl := compact.ApplyMany(input, allLeft)
+		outputr := compact.ApplyMany(input, allRight)
+		if outputl != outputr {
+			log.Fatal("merge failure: ", input, "\n", left, " x ", right, "\n", encodedl, " x ", encodedr, "\n", outputl, " x ", outputr)
+		}
+
+		output := outputl
+		encoded, err := json.Marshal([]interface{}{
+			input,
+			output,
+			[]string{left},
+			[]string{right},
+			encodedl[1:],
+			encodedr[1:],
+		})
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("%s\t\t%s", first, string(encoded))
+		first = ",\n"
+	})
+}

--- a/tools/lib/compact.go
+++ b/tools/lib/compact.go
@@ -42,7 +42,7 @@ func (Compact) Decode(s string) (string, dot.Change) {
 		parts := strings.Split(right, "=")
 		input := left + mid + parts[0] + parts[1]
 		offset := len(utf16.Encode([]rune(left)))
-		distance := -len(utf16.Encode([]rune(parts[0])))
+		distance := len(utf16.Encode([]rune(parts[0])))
 		count := len(utf16.Encode([]rune(mid)))
 		move := &dot.MoveInfo{Offset: offset, Count: count, Distance: distance}
 		return input, dot.Change{Move: move}


### PR DESCRIPTION
Adds 2919 move tests to be specific.

I have some doubts on whether these are all currently tested on the core [dot](https://github.com/dotchain/dot) project or not.  But will take a pass at converting these to actual tests there at some point.